### PR TITLE
Don't blow up legacy PHP

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,3 +52,17 @@ jobs:
           vendor/bin/phpunit --version | head -n1 >&2
 
           vendor/bin/phpunit --verbose $args
+  # Verifies that the plugin entry point still parses on PHP 5.3, users of 5.3
+  # cannot use this Composer plugin but at least it won't break their Composer.
+  legacy:
+    runs-on: ubuntu-latest
+    name: PHP 5.3
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@151d1849c224dd5757287959c3c93f9e748f24d1
+        with:
+          php-version: 5.3
+      - name: Parse ComposerPlugin.php
+        run: php -l src/ComposerPlugin.php
+      - name: Parse ComposerPlugin.fake.php
+        run: php -l src/ComposerPlugin.fake.php

--- a/src/ComposerPlugin.fake.php
+++ b/src/ComposerPlugin.fake.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Cs278\ComposerAudit;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+/**
+ * Composer Audit Plugin declaration.
+ *
+ * @internal This class is used when loading the plugin with PHP < 7.1.
+ */
+final class ComposerPlugin implements PluginInterface
+{
+    public function activate(Composer $composer, IOInterface $io)
+    {
+
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+
+    }
+}

--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -2,33 +2,8 @@
 
 namespace Cs278\ComposerAudit;
 
-use Composer\Composer;
-use Composer\IO\IOInterface;
-use Composer\Plugin\PluginInterface;
-use Composer\Plugin\Capable;
-use Composer\Plugin\Capability\CommandProvider as CommandProviderCapability;
-
-final class ComposerPlugin implements PluginInterface, Capable
-{
-    public function activate(Composer $composer, IOInterface $io)
-    {
-
-    }
-
-    public function deactivate(Composer $composer, IOInterface $io)
-    {
-
-    }
-
-    public function uninstall(Composer $composer, IOInterface $io)
-    {
-
-    }
-
-    public function getCapabilities()
-    {
-        return array(
-            CommandProviderCapability::class => CommandProvider::class,
-        );
-    }
+if (\PHP_VERSION_ID >= 70100) {
+    require __DIR__.'/ComposerPlugin.real.php';
+} else {
+    require __DIR__.'/ComposerPlugin.fake.php';
 }

--- a/src/ComposerPlugin.real.php
+++ b/src/ComposerPlugin.real.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Cs278\ComposerAudit;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+use Composer\Plugin\Capable;
+use Composer\Plugin\Capability\CommandProvider as CommandProviderCapability;
+
+/**
+ * Composer Audit Plugin declaration.
+ *
+ * Note this file intentionally remains compatible with PHP 5.3 syntax.
+ */
+final class ComposerPlugin implements PluginInterface, Capable
+{
+    public function activate(Composer $composer, IOInterface $io)
+    {
+
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+
+    }
+
+    public function getCapabilities()
+    {
+        return [
+            CommandProviderCapability::class => CommandProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
Prevent fatal errors when having this plugin installed globally and using legacy version.
