### PR TITLE
Ignore advisory by CVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,54 @@ does not exist or it’s more than an hour old. For example:
 composer audit --update
 ```
 
+Configuration
+-------------
+
+Composer Audit can be configured using the [`extra`][composer.json extra] property
+in your `composer.json` file, all configuration should be supplied under the
+`composer-audit` key.
+
+```json
+{
+    ...
+    "extra": {
+        ...
+        "composer-audit": {
+            "option1": "super"
+        },
+        ...
+    },
+    ...
+}
+```
+
+### Ignoring an advisory
+
+Currently only filtering advisories by CVE is possible, further options are planned.
+
+#### Ignoring an advisory by CVE
+
+You are able to ignore warnings about an advisory by filtering based on its CVE
+reference, this is useful if you decide the risk is acceptable or not applicable
+and you cannot otherwise upgrade the package to resolve the problem.
+
+```json
+{
+    ...
+    "extra": {
+        ...
+        "composer-audit": {
+            "ignore": [
+                {"type": "cve", "value": "CVE-2000-1234567"},
+                {"type": "cve", "value": "CVE-2000-7654321"}
+            ]
+        },
+        ...
+    },
+    ...
+}
+```
+
 Example
 -------
 
@@ -88,5 +136,6 @@ composer://symfony/http-foundation (2.0.4)
 
 Hyperlinks will be rendered to the appropriate CVE and advisory where available.
 
+[composer.json extra]: https://getcomposer.org/doc/04-schema.md#extra
 [FriendsOfPHP/security-advisories]: https://github.com/FriendsOfPHP/security-advisories
 [security.symfony.com]: https://security.symfony.com/

--- a/tests/integration/ignore--broken-show-warnings.test
+++ b/tests/integration/ignore--broken-show-warnings.test
@@ -1,0 +1,57 @@
+--TEST--
+Test invalid ignore rules are handled.
+--CONDITION--
+true
+--COMPOSER--
+{
+    "require-dev": {
+        "symfony/http-foundation": "=2.0.4"
+    },
+    "extra": {
+        "composer-audit": {
+            "ignore": [
+                {"type": "package", "value": "foo/bar"},
+                {"type": "cve", "value": ""},
+                {"type": "", "value": "test"}
+            ]
+        }
+    }
+}
+--ARGS--
+-vv
+--EXPECT-EXIT--
+1
+--EXPECT-OUTPUT--
+Ignoring invalid ignore rule: `{"type":"package","value":"foo\/bar"}`
+Ignoring invalid ignore rule: `{"type":"cve","value":""}`
+Ignoring invalid ignore rule: `{"type":"","value":"test"}`
+Found 9 advisories affecting 1 package(s).
+
+composer://symfony/http-foundation (2.0.4)
+* Request::getClientIp() when the trust proxy mode is enabled
+  - <https://symfony.com/blog/security-release-symfony-2-0-19-and-2-1-4>
+* CVE-2012-6431 Routes behind a firewall are accessible even when not logged in
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-6431>
+  - <https://symfony.com/blog/security-release-symfony-2-0-20-and-2-1-5-released>
+* CVE-2013-4752 Request::getHost() poisoning
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-4752>
+  - <https://symfony.com/blog/security-releases-symfony-2-0-24-2-1-12-2-2-5-and-2-3-3-released>
+* CVE-2014-5244 Denial of service with a malicious HTTP Host header
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5244>
+  - <https://symfony.com/cve-2014-5244>
+* CVE-2014-6061 Security issue when parsing the Authorization header
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6061>
+  - <https://symfony.com/cve-2014-6061>
+* CVE-2015-2309 Unsafe methods in the Request class
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2309>
+  - <https://symfony.com/cve-2015-2309>
+* CVE-2018-11386 Denial of service when using PDOSessionHandler
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11386>
+  - <https://symfony.com/cve-2018-11386>
+* CVE-2018-14773 Remove support for legacy and risky HTTP headers
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14773>
+  - <https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers>
+* CVE-2019-18888 Prevent argument injection in a MimeTypeGuesser
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18888>
+  - <https://symfony.com/cve-2019-18888>
+

--- a/tests/integration/ignore--broken.test
+++ b/tests/integration/ignore--broken.test
@@ -1,0 +1,53 @@
+--TEST--
+Test invalid ignore rules are handled.
+--CONDITION--
+true
+--COMPOSER--
+{
+    "require-dev": {
+        "symfony/http-foundation": "=2.0.4"
+    },
+    "extra": {
+        "composer-audit": {
+            "ignore": [
+                {"type": "package", "value": "foo/bar"},
+                {"type": "cve", "value": ""},
+                {"type": "", "value": "test"}
+            ]
+        }
+    }
+}
+--ARGS--
+--EXPECT-EXIT--
+1
+--EXPECT-OUTPUT--
+Found 9 advisories affecting 1 package(s).
+
+composer://symfony/http-foundation (2.0.4)
+* Request::getClientIp() when the trust proxy mode is enabled
+  - <https://symfony.com/blog/security-release-symfony-2-0-19-and-2-1-4>
+* CVE-2012-6431 Routes behind a firewall are accessible even when not logged in
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-6431>
+  - <https://symfony.com/blog/security-release-symfony-2-0-20-and-2-1-5-released>
+* CVE-2013-4752 Request::getHost() poisoning
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-4752>
+  - <https://symfony.com/blog/security-releases-symfony-2-0-24-2-1-12-2-2-5-and-2-3-3-released>
+* CVE-2014-5244 Denial of service with a malicious HTTP Host header
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5244>
+  - <https://symfony.com/cve-2014-5244>
+* CVE-2014-6061 Security issue when parsing the Authorization header
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6061>
+  - <https://symfony.com/cve-2014-6061>
+* CVE-2015-2309 Unsafe methods in the Request class
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2309>
+  - <https://symfony.com/cve-2015-2309>
+* CVE-2018-11386 Denial of service when using PDOSessionHandler
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11386>
+  - <https://symfony.com/cve-2018-11386>
+* CVE-2018-14773 Remove support for legacy and risky HTTP headers
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14773>
+  - <https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers>
+* CVE-2019-18888 Prevent argument injection in a MimeTypeGuesser
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18888>
+  - <https://symfony.com/cve-2019-18888>
+

--- a/tests/integration/ignore--cve-with-error.test
+++ b/tests/integration/ignore--cve-with-error.test
@@ -1,0 +1,23 @@
+--TEST--
+Test that an ignored CVE does not result in an error.
+--CONDITION--
+true
+--COMPOSER--
+{
+    "require-dev": {
+        "symfony/security-core": "=5.2.7"
+    },
+    "extra": {
+        "composer-audit": {
+            "ignore": [
+                {"type": "cve", "value": "CVE-2021-21424"}
+            ]
+        }
+    }
+}
+--ARGS--
+--EXPECT-EXIT--
+0
+--EXPECT-OUTPUT--
+Found 1 advisories affecting 1 package(s).
+1 advisories were ignored.

--- a/tests/integration/ignore--cve.test
+++ b/tests/integration/ignore--cve.test
@@ -1,0 +1,45 @@
+--TEST--
+Test that an ignored CVE does not result in an error.
+--CONDITION--
+true
+--COMPOSER--
+{
+    "require-dev": {
+        "symfony/http-foundation": "=2.0.4"
+    },
+    "extra": {
+        "composer-audit": {
+            "ignore": [
+                {"type": "cve", "value": "CVE-2012-6431"},
+                {"type": "cve", "value": "CVE-2013-4752"},
+                {"type": "cve", "value": "CVE-2014-5244"}
+            ]
+        }
+    }
+}
+--ARGS--
+--EXPECT-EXIT--
+2
+--EXPECT-OUTPUT--
+Found 9 advisories affecting 1 package(s).
+
+composer://symfony/http-foundation (2.0.4)
+* Request::getClientIp() when the trust proxy mode is enabled
+  - <https://symfony.com/blog/security-release-symfony-2-0-19-and-2-1-4>
+* CVE-2014-6061 Security issue when parsing the Authorization header
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6061>
+  - <https://symfony.com/cve-2014-6061>
+* CVE-2015-2309 Unsafe methods in the Request class
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2309>
+  - <https://symfony.com/cve-2015-2309>
+* CVE-2018-11386 Denial of service when using PDOSessionHandler
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11386>
+  - <https://symfony.com/cve-2018-11386>
+* CVE-2018-14773 Remove support for legacy and risky HTTP headers
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14773>
+  - <https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers>
+* CVE-2019-18888 Prevent argument injection in a MimeTypeGuesser
+  - <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18888>
+  - <https://symfony.com/cve-2019-18888>
+
+3 advisories were ignored.


### PR DESCRIPTION
Sometimes you need to be able to ignore an advisory, there can be good reasons to do this and it's up to the user to judge this for themselves.

See the README for how to use this feature.
