### PR TITLE
Fix build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "cs278/mktemp": "^1",
-        "composer/composer": "^1 || ^2@RC",
+        "composer/composer": "^2@RC",
         "composer/semver": "*",
         "symfony/filesystem": "^4.4 || ^5 || ^6",
         "symfony/phpunit-bridge": "^5.2",

--- a/src/AdvisoriesManager.php
+++ b/src/AdvisoriesManager.php
@@ -57,7 +57,15 @@ final class AdvisoriesManager
             );
         }
 
-        return new self($installer);
+        $manager = new self($installer);
+
+        // Allow the advisories package to be overloaded using an environment variable.
+        // COMPOSER_AUDIT_ADVISORIES_PACKAGE=cs278/security-advisories:dev-special
+        if ('' !== $package = (string) getenv('COMPOSER_AUDIT_ADVISORIES_PACKAGE')) {
+            [$manager->packageName, $manager->packageConstraint] = explode(':', $package, 2);
+        }
+
+        return $manager;
     }
 
     public function mustUpdate()

--- a/src/AuditCommand.php
+++ b/src/AuditCommand.php
@@ -60,7 +60,7 @@ final class AuditCommand extends BaseCommand
         $this->updateAdvisories = (bool) $input->getOption('update');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $advisoriesManager = AdvisoriesManager::create($this->getComposer());
 

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -112,6 +112,7 @@ final class IntegrationTest extends TestCase
                 'COMPOSER_HOME' => $workingDir.'/.composer',
                 'COMPOSER_CACHE_DIR' => self::$cacheDir,
                 'COMPOSER_AUDIT_TEST' => 1,
+                'COMPOSER_AUDIT_ADVISORIES_PACKAGE' => 'sensiolabs/security-advisories:dev-master#d1749520b5e16eceeb6bceeae73af790773a371b'
             ]);
         };
 


### PR DESCRIPTION
Pins the security advisories in the integration tests so that they don't keep requiring updates.

Removes testing of Composer 1.x which is very EOL. You can still try and use this plugin with 1.x but I doubt very much works anymore anyway.