### PR TITLE
Only load polyfills once

### DIFF
--- a/src/PolyfillLoader.php
+++ b/src/PolyfillLoader.php
@@ -10,8 +10,16 @@ use Composer\IO\IOInterface;
  */
 final class PolyfillLoader
 {
+    private static $loaded = false;
+
     public static function load(Composer $composer, IOInterface $io)
     {
+        if (self::$loaded) {
+            return;
+        }
+
+        self::$loaded = true;
+
         $packages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
         $includeFiles = [];
 


### PR DESCRIPTION
One of the Symfony polyfill packages is declaring constants without checking if they are defined, this is causing errors due to duplicate definitions.
